### PR TITLE
add option cc-null-collection-elements

### DIFF
--- a/cc-xjc-plugin/src/main/resources/net/sourceforge/ccxjc/PluginImpl.properties
+++ b/cc-xjc-plugin/src/main/resources/net/sourceforge/ccxjc/PluginImpl.properties
@@ -29,3 +29,4 @@ cloneableTypesInfo=Cloneable types:  {0}
 immutableTypesInfo=Immutable types: {0}
 stringTypesUsage=list of names of string based datatype classes separated by ''{0}''.
 stringTypesInfo=String types: {0}
+copyNullCollectionElementsUsage=copy ''null'' elements of collections in copy constructors. Default: disabled

--- a/cc-xjc-plugin/src/main/resources/net/sourceforge/ccxjc/PluginImpl_de.properties
+++ b/cc-xjc-plugin/src/main/resources/net/sourceforge/ccxjc/PluginImpl_de.properties
@@ -29,3 +29,4 @@ cloneableTypesInfo=Klonbare Typen:  {0}
 immutableTypesInfo=Unver\u00e4nderbare Typen: {0}
 stringTypesUsage=Liste von Namen zeichenkettenbasierter Datentyp-Klassen getrennt mit ''{0}''.
 stringTypesInfo=Zeichenkettenbasierte Datentypen: {0}
+copyNullCollectionElementsUsage=kopiert ''null''-Element von Collection im Kopier-Konstruktor. Standard: deaktiviert

--- a/cc-xjc-plugin/src/main/resources/net/sourceforge/ccxjc/PluginImpl_en.properties
+++ b/cc-xjc-plugin/src/main/resources/net/sourceforge/ccxjc/PluginImpl_en.properties
@@ -29,3 +29,4 @@ cloneableTypesInfo=Cloneable types:  {0}
 immutableTypesInfo=Immutable types: {0}
 stringTypesUsage=list of names of string based datatype classes separated by ''{0}''.
 stringTypesInfo=String types: {0}
+copyNullCollectionElementsUsage=copy ''null'' elements of collections in copy constructors. Default: disabled

--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -197,6 +197,13 @@ CC-XJC
 
             * jakarta.activation.MimeType
 
+** -cc-null-collection-elements (since ?)
+
+    The '-cc-null-collection-elements' option got introduced in version ?. It can
+    be used to allow the copy of 'null'-elements contained in collections that
+    are copied in the constructor. Before version ? 'null'-elements would be
+    dropped silently when copying/cloning collections.
+
 * Support
 
   Development of CC-XJC is community driven. Please file any issues with the


### PR DESCRIPTION
This option allows to copy null-elements between collections. Currently 'null'-elements are silently omited because they are not "instanceof SomeClass"