### PR TITLE
fix missing clone method on when not using -Xcopyable

### DIFF
--- a/cc-xjc-it/pom.xml
+++ b/cc-xjc-it/pom.xml
@@ -595,9 +595,9 @@
   </build>
   <dependencies>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.8.2</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/cc-xjc-it/pom.xml
+++ b/cc-xjc-it/pom.xml
@@ -104,7 +104,6 @@
                   <arg>-XtoString</arg>
                   <arg>-Xequals</arg>
                   <arg>-XhashCode</arg>
-                  <arg>-Xcopyable</arg>
                 </args>
                 <schemaDirectory>src/main/schemas</schemaDirectory>
                 <bindingDirectory>src/main/jaxb</bindingDirectory>
@@ -133,7 +132,6 @@
                   <arg>-XtoString</arg>
                   <arg>-Xequals</arg>
                   <arg>-XhashCode</arg>
-                  <arg>-Xcopyable</arg>
                 </args>
                 <schemaDirectory>src/main/schemas</schemaDirectory>
                 <bindingDirectory>src/main/jaxb</bindingDirectory>
@@ -162,7 +160,6 @@
                   <arg>-XtoString</arg>
                   <arg>-Xequals</arg>
                   <arg>-XhashCode</arg>
-                  <arg>-Xcopyable</arg>
                 </args>
                 <schemaDirectory>src/main/schemas</schemaDirectory>
                 <bindingDirectory>src/main/jaxb</bindingDirectory>
@@ -191,7 +188,6 @@
                   <arg>-XtoString</arg>
                   <arg>-Xequals</arg>
                   <arg>-XhashCode</arg>
-                  <arg>-Xcopyable</arg>
                 </args>
                 <schemaDirectory>src/main/schemas</schemaDirectory>
                 <bindingDirectory>src/main/jaxb</bindingDirectory>
@@ -221,7 +217,6 @@
                   <arg>-XtoString</arg>
                   <arg>-Xequals</arg>
                   <arg>-XhashCode</arg>
-                  <arg>-Xcopyable</arg>
                 </args>
                 <schemaDirectory>src/main/schemas</schemaDirectory>
                 <bindingDirectory>src/main/jaxb</bindingDirectory>
@@ -250,7 +245,6 @@
                   <arg>-XtoString</arg>
                   <arg>-Xequals</arg>
                   <arg>-XhashCode</arg>
-                  <arg>-Xcopyable</arg>
                 </args>
                 <schemaDirectory>src/main/schemas</schemaDirectory>
                 <bindingDirectory>src/main/jaxb</bindingDirectory>
@@ -279,7 +273,6 @@
                   <arg>-XtoString</arg>
                   <arg>-Xequals</arg>
                   <arg>-XhashCode</arg>
-                  <arg>-Xcopyable</arg>
                 </args>
                 <schemaDirectory>src/main/schemas</schemaDirectory>
                 <bindingDirectory>src/main/jaxb</bindingDirectory>
@@ -308,7 +301,6 @@
                   <arg>-XtoString</arg>
                   <arg>-Xequals</arg>
                   <arg>-XhashCode</arg>
-                  <arg>-Xcopyable</arg>
                 </args>
                 <schemaDirectory>src/main/schemas</schemaDirectory>
                 <bindingDirectory>src/main/jaxb</bindingDirectory>
@@ -338,7 +330,6 @@
                   <arg>-XtoString</arg>
                   <arg>-Xequals</arg>
                   <arg>-XhashCode</arg>
-                  <arg>-Xcopyable</arg>
                 </args>
                 <schemaDirectory>src/main/schemas</schemaDirectory>
                 <bindingDirectory>src/main/jaxb</bindingDirectory>
@@ -367,7 +358,6 @@
                   <arg>-XtoString</arg>
                   <arg>-Xequals</arg>
                   <arg>-XhashCode</arg>
-                  <arg>-Xcopyable</arg>
                 </args>
                 <schemaDirectory>src/main/schemas</schemaDirectory>
                 <bindingDirectory>src/main/jaxb</bindingDirectory>
@@ -396,7 +386,6 @@
                   <arg>-XtoString</arg>
                   <arg>-Xequals</arg>
                   <arg>-XhashCode</arg>
-                  <arg>-Xcopyable</arg>
                 </args>
                 <schemaDirectory>src/main/schemas</schemaDirectory>
                 <bindingDirectory>src/main/jaxb</bindingDirectory>
@@ -425,7 +414,6 @@
                   <arg>-XtoString</arg>
                   <arg>-Xequals</arg>
                   <arg>-XhashCode</arg>
-                  <arg>-Xcopyable</arg>
                 </args>
                 <schemaDirectory>src/main/schemas</schemaDirectory>
                 <bindingDirectory>src/main/jaxb</bindingDirectory>
@@ -455,7 +443,6 @@
                   <arg>-XtoString</arg>
                   <arg>-Xequals</arg>
                   <arg>-XhashCode</arg>
-                  <arg>-Xcopyable</arg>
                 </args>
                 <schemaDirectory>src/main/schemas</schemaDirectory>
                 <bindingDirectory>src/main/jaxb</bindingDirectory>
@@ -484,7 +471,6 @@
                   <arg>-XtoString</arg>
                   <arg>-Xequals</arg>
                   <arg>-XhashCode</arg>
-                  <arg>-Xcopyable</arg>
                 </args>
                 <schemaDirectory>src/main/schemas</schemaDirectory>
                 <bindingDirectory>src/main/jaxb</bindingDirectory>
@@ -513,7 +499,6 @@
                   <arg>-XtoString</arg>
                   <arg>-Xequals</arg>
                   <arg>-XhashCode</arg>
-                  <arg>-Xcopyable</arg>
                 </args>
                 <schemaDirectory>src/main/schemas</schemaDirectory>
                 <bindingDirectory>src/main/jaxb</bindingDirectory>
@@ -542,12 +527,41 @@
                   <arg>-XtoString</arg>
                   <arg>-Xequals</arg>
                   <arg>-XhashCode</arg>
-                  <arg>-Xcopyable</arg>
                 </args>
                 <schemaDirectory>src/main/schemas</schemaDirectory>
                 <bindingDirectory>src/main/jaxb</bindingDirectory>
                 <bindingIncludes>
                   <bindingInclude>cc-xjc-it-indexed-no-value-class-public.xjb</bindingInclude>
+                </bindingIncludes>
+                <extension>true</extension>
+                <episode>false</episode>
+                <forceRegenerate>true</forceRegenerate>
+                <verbose>true</verbose>
+              </configuration>
+            </execution>
+            <execution>
+              <!-- a test that combines jaxb-basics' "-Xcopyable" with "-copy-constructor" (ccxjc will not write a second clone()) -->
+              <id>xjc-indexed-collection-type-no-value-class-public-copyable-basics</id>
+              <phase>generate-sources</phase>
+              <goals>
+                <goal>generate</goal>
+              </goals>
+              <configuration>
+                <args>
+                  <arg>-Xcopyable</arg>
+                  <arg>-copy-constructor</arg>
+                  <arg>-cc-visibility</arg>
+                  <arg>public</arg>
+                  <arg>-cc-nullable</arg>
+                  <arg>-cc-hierarchical</arg>
+                  <arg>-XtoString</arg>
+                  <arg>-Xequals</arg>
+                  <arg>-XhashCode</arg>
+                </args>
+                <schemaDirectory>src/main/schemas</schemaDirectory>
+                <bindingDirectory>src/main/jaxb</bindingDirectory>
+                <bindingIncludes>
+                  <bindingInclude>cc-xjc-it-copyable-jaxbbasics.xjb</bindingInclude>
                 </bindingIncludes>
                 <extension>true</extension>
                 <episode>false</episode>

--- a/cc-xjc-it/src/main/java/net/sourceforge/ccxjc/it/ChoiceComplexTypeTest.java
+++ b/cc-xjc-it/src/main/java/net/sourceforge/ccxjc/it/ChoiceComplexTypeTest.java
@@ -30,7 +30,7 @@ package net.sourceforge.ccxjc.it;
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBElement;
 import net.sourceforge.ccxjc.it.model.priv.collections.valueclass.ccxjcit.ChoiceComplexType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the {@code ChoiceComplexType} complex type.

--- a/cc-xjc-it/src/main/java/net/sourceforge/ccxjc/it/SimpleTypeAttributesCollectionsTest.java
+++ b/cc-xjc-it/src/main/java/net/sourceforge/ccxjc/it/SimpleTypeAttributesCollectionsTest.java
@@ -38,8 +38,8 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 import net.sourceforge.ccxjc.it.model.copyable_jaxbbasics.valueclass.ccxjcit.SimpleTypeAttributes;
 import org.apache.commons.lang.SerializationUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the {@code SimpleTypeAttributes} complex type.
@@ -144,7 +144,7 @@ public class SimpleTypeAttributesCollectionsTest
 
     public void assertTestBytes( final byte[] bytes )
     {
-        Assert.assertArrayEquals(this.getTestBytes(), bytes);
+        Assertions.assertArrayEquals(this.getTestBytes(), bytes);
     }
 
     public SimpleTypeAttributes getTestSimpleTypeAttributes() throws DatatypeConfigurationException
@@ -203,51 +203,51 @@ public class SimpleTypeAttributesCollectionsTest
 
     public void assertTestSimpleTypeAttributes( final SimpleTypeAttributes a ) throws DatatypeConfigurationException
     {
-        Assert.assertEquals( "any", a.getAnySimpleType() );
-        Assert.assertEquals( "anyURI", a.getAnyURI() );
+        Assertions.assertEquals( "any", a.getAnySimpleType() );
+        Assertions.assertEquals( "anyURI", a.getAnyURI() );
         this.assertTestBytes( a.getBase64Binary() );
-        Assert.assertTrue( a.isBoolean() );
-        Assert.assertEquals( 1, a.getByte() );
-        Assert.assertEquals( this.getTestCalendar(), a.getDate() );
-        Assert.assertEquals( this.getTestCalendar(), a.getDateTime() );
-        Assert.assertEquals( BigDecimal.TEN, a.getDecimal() );
-        Assert.assertEquals(100.0D, a.getDouble(), CommonHelper.DOUBLE_EPSILON );
-        Assert.assertEquals( this.getTestDuration(), a.getDuration() );
-        Assert.assertEquals( this.getTestEntities(), a.getENTITIES() );
-        Assert.assertEquals( "ENTITY", a.getENTITY() );
-        Assert.assertEquals(100.0F, a.getFloat(), CommonHelper.FLOAT_EPSILON );
-        Assert.assertEquals( this.getTestCalendar(), a.getGDay() );
-        Assert.assertEquals( this.getTestCalendar(), a.getGMonth() );
-        Assert.assertEquals( this.getTestCalendar(), a.getGMonthDay() );
-        Assert.assertEquals( this.getTestCalendar(), a.getGYear() );
-        Assert.assertEquals( this.getTestCalendar(), a.getGYearMonth() );
+        Assertions.assertTrue( a.isBoolean() );
+        Assertions.assertEquals( 1, a.getByte() );
+        Assertions.assertEquals( this.getTestCalendar(), a.getDate() );
+        Assertions.assertEquals( this.getTestCalendar(), a.getDateTime() );
+        Assertions.assertEquals( BigDecimal.TEN, a.getDecimal() );
+        Assertions.assertEquals(100.0D, a.getDouble(), CommonHelper.DOUBLE_EPSILON );
+        Assertions.assertEquals( this.getTestDuration(), a.getDuration() );
+        Assertions.assertEquals( this.getTestEntities(), a.getENTITIES() );
+        Assertions.assertEquals( "ENTITY", a.getENTITY() );
+        Assertions.assertEquals(100.0F, a.getFloat(), CommonHelper.FLOAT_EPSILON );
+        Assertions.assertEquals( this.getTestCalendar(), a.getGDay() );
+        Assertions.assertEquals( this.getTestCalendar(), a.getGMonth() );
+        Assertions.assertEquals( this.getTestCalendar(), a.getGMonthDay() );
+        Assertions.assertEquals( this.getTestCalendar(), a.getGYear() );
+        Assertions.assertEquals( this.getTestCalendar(), a.getGYearMonth() );
         this.assertTestBytes( a.getHexBinary() );
-        Assert.assertEquals( "ID", a.getID() );
-        Assert.assertEquals( "ID", a.getIDREF() );
-        Assert.assertEquals( this.getTestIdRefs(), a.getIDREFS() );
-        Assert.assertEquals( 100, a.getInt() );
-        Assert.assertEquals( BigInteger.TEN, a.getInteger() );
-        Assert.assertEquals( "en", a.getLanguage() );
-        Assert.assertEquals( 100L, a.getLong() );
-        Assert.assertEquals( "NCName", a.getNCName() );
-        Assert.assertEquals( "NMTOKEN", a.getNMTOKEN() );
-        Assert.assertEquals( this.getTestTokens(), a.getNMTOKENS() );
-        Assert.assertEquals( this.getTestQName(), a.getNOTATION() );
-        Assert.assertEquals( "name", a.getName() );
-        Assert.assertEquals( BigInteger.valueOf( -100L ), a.getNegativeInteger() );
-        Assert.assertEquals( BigInteger.TEN, a.getNonNegativeInteger() );
-        Assert.assertEquals( BigInteger.valueOf( -100L ), a.getNonPositiveInteger() );
-        Assert.assertEquals( "normalized", a.getNormalizedString() );
-        Assert.assertEquals( BigInteger.TEN, a.getPositiveInteger() );
-        Assert.assertEquals( this.getTestQName(), a.getQName() );
-        Assert.assertEquals( 100, a.getShort() );
-        Assert.assertEquals( "String", a.getString() );
-        Assert.assertEquals( this.getTestCalendar(), a.getTime() );
-        Assert.assertEquals( "Token", a.getToken() );
-        Assert.assertEquals( 100, a.getUnsignedByte() );
-        Assert.assertEquals( 100, a.getUnsignedInt() );
-        Assert.assertEquals( BigInteger.TEN, a.getUnsignedLong() );
-        Assert.assertEquals( 100, a.getUnsignedShort() );
+        Assertions.assertEquals( "ID", a.getID() );
+        Assertions.assertEquals( "ID", a.getIDREF() );
+        Assertions.assertEquals( this.getTestIdRefs(), a.getIDREFS() );
+        Assertions.assertEquals( 100, a.getInt() );
+        Assertions.assertEquals( BigInteger.TEN, a.getInteger() );
+        Assertions.assertEquals( "en", a.getLanguage() );
+        Assertions.assertEquals( 100L, a.getLong() );
+        Assertions.assertEquals( "NCName", a.getNCName() );
+        Assertions.assertEquals( "NMTOKEN", a.getNMTOKEN() );
+        Assertions.assertEquals( this.getTestTokens(), a.getNMTOKENS() );
+        Assertions.assertEquals( this.getTestQName(), a.getNOTATION() );
+        Assertions.assertEquals( "name", a.getName() );
+        Assertions.assertEquals( BigInteger.valueOf( -100L ), a.getNegativeInteger() );
+        Assertions.assertEquals( BigInteger.TEN, a.getNonNegativeInteger() );
+        Assertions.assertEquals( BigInteger.valueOf( -100L ), a.getNonPositiveInteger() );
+        Assertions.assertEquals( "normalized", a.getNormalizedString() );
+        Assertions.assertEquals( BigInteger.TEN, a.getPositiveInteger() );
+        Assertions.assertEquals( this.getTestQName(), a.getQName() );
+        Assertions.assertEquals( 100, a.getShort() );
+        Assertions.assertEquals( "String", a.getString() );
+        Assertions.assertEquals( this.getTestCalendar(), a.getTime() );
+        Assertions.assertEquals( "Token", a.getToken() );
+        Assertions.assertEquals( 100, a.getUnsignedByte() );
+        Assertions.assertEquals( 100, a.getUnsignedInt() );
+        Assertions.assertEquals( BigInteger.TEN, a.getUnsignedLong() );
+        Assertions.assertEquals( 100, a.getUnsignedShort() );
     }
 
     @Test public void testSimpleTypeAttributesNull() throws Exception
@@ -317,7 +317,7 @@ public class SimpleTypeAttributesCollectionsTest
         System.out.println( "Creating " + runs + " copies using copy constructor took " + copyMillis + "ms. (" +
                             ( 100L * copyMillis / serializableMillis ) + "%)" );
 
-        Assert.assertTrue( copyMillis < serializableMillis );
+        Assertions.assertTrue( copyMillis < serializableMillis );
     }
 
 }

--- a/cc-xjc-it/src/main/java/net/sourceforge/ccxjc/it/SimpleTypeAttributesCollectionsTest.java
+++ b/cc-xjc-it/src/main/java/net/sourceforge/ccxjc/it/SimpleTypeAttributesCollectionsTest.java
@@ -36,7 +36,7 @@ import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.Duration;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
-import net.sourceforge.ccxjc.it.model.priv.collections.valueclass.ccxjcit.SimpleTypeAttributes;
+import net.sourceforge.ccxjc.it.model.copyable_jaxbbasics.valueclass.ccxjcit.SimpleTypeAttributes;
 import org.apache.commons.lang.SerializationUtils;
 import org.junit.Assert;
 import org.junit.Test;

--- a/cc-xjc-it/src/main/java/net/sourceforge/ccxjc/it/SimpleTypeAttributesIndexedTest.java
+++ b/cc-xjc-it/src/main/java/net/sourceforge/ccxjc/it/SimpleTypeAttributesIndexedTest.java
@@ -35,8 +35,8 @@ import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 import net.sourceforge.ccxjc.it.model.priv.indexed.valueclass.ccxjcit.SimpleTypeAttributes;
 import org.apache.commons.lang.SerializationUtils;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the {@code SimpleTypeAttributes} complex type.
@@ -150,22 +150,22 @@ public class SimpleTypeAttributesIndexedTest
 
     public void assertTestBytes( final byte[] bytes )
     {
-        Assert.assertArrayEquals( this.getTestBytes(), bytes );
+        Assertions.assertArrayEquals( this.getTestBytes(), bytes );
     }
 
     public void assertTestEntities( final String[] entities )
     {
-        Assert.assertArrayEquals( this.getTestEntities(), entities );
+        Assertions.assertArrayEquals( this.getTestEntities(), entities );
     }
 
     public void assertTestIdRefs( final Object[] idrefs )
     {
-        Assert.assertArrayEquals( this.getTestIdRefs(), idrefs );
+        Assertions.assertArrayEquals( this.getTestIdRefs(), idrefs );
     }
 
     public void assertTestTokens( final String[] tokens )
     {
-        Assert.assertArrayEquals( this.getTestTokens(), tokens );
+        Assertions.assertArrayEquals( this.getTestTokens(), tokens );
     }
 
     public SimpleTypeAttributes getTestSimpleTypeAttributes() throws DatatypeConfigurationException
@@ -224,51 +224,51 @@ public class SimpleTypeAttributesIndexedTest
 
     public void assertTestSimpleTypeAttributes( final SimpleTypeAttributes a ) throws DatatypeConfigurationException
     {
-        Assert.assertEquals( "any", a.getAnySimpleType() );
-        Assert.assertEquals( "anyURI", a.getAnyURI() );
+        Assertions.assertEquals( "any", a.getAnySimpleType() );
+        Assertions.assertEquals( "anyURI", a.getAnyURI() );
         this.assertTestBytes( a.getBase64Binary() );
-        Assert.assertTrue( a.isBoolean() );
-        Assert.assertEquals( 1, a.getByte() );
-        Assert.assertEquals( this.getTestCalendar(), a.getDate() );
-        Assert.assertEquals( this.getTestCalendar(), a.getDateTime() );
-        Assert.assertEquals( BigDecimal.TEN, a.getDecimal() );
-        Assert.assertEquals(100.0D, a.getDouble(), CommonHelper.DOUBLE_EPSILON );
-        Assert.assertEquals( this.getTestDuration(), a.getDuration() );
+        Assertions.assertTrue( a.isBoolean() );
+        Assertions.assertEquals( 1, a.getByte() );
+        Assertions.assertEquals( this.getTestCalendar(), a.getDate() );
+        Assertions.assertEquals( this.getTestCalendar(), a.getDateTime() );
+        Assertions.assertEquals( BigDecimal.TEN, a.getDecimal() );
+        Assertions.assertEquals(100.0D, a.getDouble(), CommonHelper.DOUBLE_EPSILON );
+        Assertions.assertEquals( this.getTestDuration(), a.getDuration() );
         this.assertTestEntities( a.getENTITIES() );
-        Assert.assertEquals( "ENTITY", a.getENTITY() );
-        Assert.assertEquals(100.0F, a.getFloat(), CommonHelper.FLOAT_EPSILON );
-        Assert.assertEquals( this.getTestCalendar(), a.getGDay() );
-        Assert.assertEquals( this.getTestCalendar(), a.getGMonth() );
-        Assert.assertEquals( this.getTestCalendar(), a.getGMonthDay() );
-        Assert.assertEquals( this.getTestCalendar(), a.getGYear() );
-        Assert.assertEquals( this.getTestCalendar(), a.getGYearMonth() );
+        Assertions.assertEquals( "ENTITY", a.getENTITY() );
+        Assertions.assertEquals(100.0F, a.getFloat(), CommonHelper.FLOAT_EPSILON );
+        Assertions.assertEquals( this.getTestCalendar(), a.getGDay() );
+        Assertions.assertEquals( this.getTestCalendar(), a.getGMonth() );
+        Assertions.assertEquals( this.getTestCalendar(), a.getGMonthDay() );
+        Assertions.assertEquals( this.getTestCalendar(), a.getGYear() );
+        Assertions.assertEquals( this.getTestCalendar(), a.getGYearMonth() );
         this.assertTestBytes( a.getHexBinary() );
-        Assert.assertEquals( "ID", a.getID() );
-        Assert.assertEquals( "ID", a.getIDREF() );
+        Assertions.assertEquals( "ID", a.getID() );
+        Assertions.assertEquals( "ID", a.getIDREF() );
         this.assertTestIdRefs( a.getIDREFS() );
-        Assert.assertEquals( 100, a.getInt() );
-        Assert.assertEquals( BigInteger.TEN, a.getInteger() );
-        Assert.assertEquals( "en", a.getLanguage() );
-        Assert.assertEquals( 100L, a.getLong() );
-        Assert.assertEquals( "NCName", a.getNCName() );
-        Assert.assertEquals( "NMTOKEN", a.getNMTOKEN() );
+        Assertions.assertEquals( 100, a.getInt() );
+        Assertions.assertEquals( BigInteger.TEN, a.getInteger() );
+        Assertions.assertEquals( "en", a.getLanguage() );
+        Assertions.assertEquals( 100L, a.getLong() );
+        Assertions.assertEquals( "NCName", a.getNCName() );
+        Assertions.assertEquals( "NMTOKEN", a.getNMTOKEN() );
         this.assertTestTokens( a.getNMTOKENS() );
-        Assert.assertEquals( this.getTestQName(), a.getNOTATION() );
-        Assert.assertEquals( "name", a.getName() );
-        Assert.assertEquals( BigInteger.valueOf( -100L ), a.getNegativeInteger() );
-        Assert.assertEquals( BigInteger.TEN, a.getNonNegativeInteger() );
-        Assert.assertEquals( BigInteger.valueOf( -100L ), a.getNonPositiveInteger() );
-        Assert.assertEquals( "normalized", a.getNormalizedString() );
-        Assert.assertEquals( BigInteger.TEN, a.getPositiveInteger() );
-        Assert.assertEquals( this.getTestQName(), a.getQName() );
-        Assert.assertEquals( 100, a.getShort() );
-        Assert.assertEquals( "String", a.getString() );
-        Assert.assertEquals( this.getTestCalendar(), a.getTime() );
-        Assert.assertEquals( "Token", a.getToken() );
-        Assert.assertEquals( 100, a.getUnsignedByte() );
-        Assert.assertEquals( 100, a.getUnsignedInt() );
-        Assert.assertEquals( BigInteger.TEN, a.getUnsignedLong() );
-        Assert.assertEquals( 100, a.getUnsignedShort() );
+        Assertions.assertEquals( this.getTestQName(), a.getNOTATION() );
+        Assertions.assertEquals( "name", a.getName() );
+        Assertions.assertEquals( BigInteger.valueOf( -100L ), a.getNegativeInteger() );
+        Assertions.assertEquals( BigInteger.TEN, a.getNonNegativeInteger() );
+        Assertions.assertEquals( BigInteger.valueOf( -100L ), a.getNonPositiveInteger() );
+        Assertions.assertEquals( "normalized", a.getNormalizedString() );
+        Assertions.assertEquals( BigInteger.TEN, a.getPositiveInteger() );
+        Assertions.assertEquals( this.getTestQName(), a.getQName() );
+        Assertions.assertEquals( 100, a.getShort() );
+        Assertions.assertEquals( "String", a.getString() );
+        Assertions.assertEquals( this.getTestCalendar(), a.getTime() );
+        Assertions.assertEquals( "Token", a.getToken() );
+        Assertions.assertEquals( 100, a.getUnsignedByte() );
+        Assertions.assertEquals( 100, a.getUnsignedInt() );
+        Assertions.assertEquals( BigInteger.TEN, a.getUnsignedLong() );
+        Assertions.assertEquals( 100, a.getUnsignedShort() );
     }
 
     @Test public void testSimpleTypeAttributesNull() throws Exception
@@ -346,7 +346,7 @@ public class SimpleTypeAttributesIndexedTest
         System.out.println( "Creating " + runs + " copies using copy constructor took " + copyMillis + "ms. (" +
                             ( 100L * copyMillis / serializableMillis ) + "%)" );
 
-        Assert.assertTrue( copyMillis < serializableMillis );
+        Assertions.assertTrue( copyMillis < serializableMillis );
     }
 
 }

--- a/cc-xjc-it/src/main/jaxb/cc-xjc-it-collections-no-value-class-package.xjb
+++ b/cc-xjc-it/src/main/jaxb/cc-xjc-it-collections-no-value-class-package.xjb
@@ -29,9 +29,9 @@
 
 -->
 <jaxb:bindings xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-               xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               jaxb:version="2.0">
+               jaxb:version="3.0">
 
   <jaxb:bindings schemaLocation="../schemas/cc-xjc-it.xsd" node="/xs:schema">
     <jaxb:globalBindings generateValueClass="false">

--- a/cc-xjc-it/src/main/jaxb/cc-xjc-it-collections-no-value-class-private.xjb
+++ b/cc-xjc-it/src/main/jaxb/cc-xjc-it-collections-no-value-class-private.xjb
@@ -29,9 +29,9 @@
 
 -->
 <jaxb:bindings xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-               xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               jaxb:version="2.0">
+               jaxb:version="3.0">
 
   <jaxb:bindings schemaLocation="../schemas/cc-xjc-it.xsd" node="/xs:schema">
     <jaxb:globalBindings generateValueClass="false">

--- a/cc-xjc-it/src/main/jaxb/cc-xjc-it-collections-no-value-class-protected.xjb
+++ b/cc-xjc-it/src/main/jaxb/cc-xjc-it-collections-no-value-class-protected.xjb
@@ -29,9 +29,9 @@
 
 -->
 <jaxb:bindings xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-               xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               jaxb:version="2.0">
+               jaxb:version="3.0">
 
   <jaxb:bindings schemaLocation="../schemas/cc-xjc-it.xsd" node="/xs:schema">
     <jaxb:globalBindings generateValueClass="false">

--- a/cc-xjc-it/src/main/jaxb/cc-xjc-it-collections-no-value-class-public.xjb
+++ b/cc-xjc-it/src/main/jaxb/cc-xjc-it-collections-no-value-class-public.xjb
@@ -29,9 +29,9 @@
 
 -->
 <jaxb:bindings xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-               xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               jaxb:version="2.0">
+               jaxb:version="3.0">
 
   <jaxb:bindings schemaLocation="../schemas/cc-xjc-it.xsd" node="/xs:schema">
     <jaxb:globalBindings generateValueClass="false">

--- a/cc-xjc-it/src/main/jaxb/cc-xjc-it-collections-package.xjb
+++ b/cc-xjc-it/src/main/jaxb/cc-xjc-it-collections-package.xjb
@@ -29,9 +29,9 @@
 
 -->
 <jaxb:bindings xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-               xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               jaxb:version="2.0">
+               jaxb:version="3.0">
 
   <jaxb:bindings schemaLocation="../schemas/cc-xjc-it.xsd" node="/xs:schema">
     <jaxb:globalBindings>

--- a/cc-xjc-it/src/main/jaxb/cc-xjc-it-collections-private.xjb
+++ b/cc-xjc-it/src/main/jaxb/cc-xjc-it-collections-private.xjb
@@ -29,9 +29,9 @@
 
 -->
 <jaxb:bindings xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-               xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               jaxb:version="2.0">
+               jaxb:version="3.0">
 
   <jaxb:bindings schemaLocation="../schemas/cc-xjc-it.xsd" node="/xs:schema">
     <jaxb:globalBindings>

--- a/cc-xjc-it/src/main/jaxb/cc-xjc-it-collections-protected.xjb
+++ b/cc-xjc-it/src/main/jaxb/cc-xjc-it-collections-protected.xjb
@@ -29,9 +29,9 @@
 
 -->
 <jaxb:bindings xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-               xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               jaxb:version="2.0">
+               jaxb:version="3.0">
 
   <jaxb:bindings schemaLocation="../schemas/cc-xjc-it.xsd" node="/xs:schema">
     <jaxb:globalBindings>

--- a/cc-xjc-it/src/main/jaxb/cc-xjc-it-collections-public.xjb
+++ b/cc-xjc-it/src/main/jaxb/cc-xjc-it-collections-public.xjb
@@ -29,9 +29,9 @@
 
 -->
 <jaxb:bindings xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-               xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               jaxb:version="2.0">
+               jaxb:version="3.0">
 
   <jaxb:bindings schemaLocation="../schemas/cc-xjc-it.xsd" node="/xs:schema">
     <jaxb:globalBindings>

--- a/cc-xjc-it/src/main/jaxb/cc-xjc-it-copyable-jaxbbasics.xjb
+++ b/cc-xjc-it/src/main/jaxb/cc-xjc-it-copyable-jaxbbasics.xjb
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+  Copyright (C) 2009 The CC-XJC Project. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+    o Redistributions of source code must retain the above copyright
+      notice, this  list of conditions and the following disclaimer.
+
+    o Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE CC-XJC PROJECT AND CONTRIBUTORS "AS IS"
+  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+  THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+  PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE CC-XJC PROJECT OR
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+  OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+  WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+  OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+  ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+-->
+<jaxb:bindings xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+               xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+               xmlns:xs="http://www.w3.org/2001/XMLSchema"
+               jaxb:version="3.0">
+
+  <jaxb:bindings schemaLocation="../schemas/cc-xjc-it.xsd" node="/xs:schema">
+    <jaxb:globalBindings>
+      <jaxb:serializable uid="1"/>
+    </jaxb:globalBindings>
+    <jaxb:schemaBindings>
+      <jaxb:package name="net.sourceforge.ccxjc.it.model.copyable_jaxbbasics.valueclass.ccxjcit"/>
+    </jaxb:schemaBindings>
+    <jaxb:bindings node=".//xs:complexType[@name='RefClassCustomizationType']">
+      <jaxb:class ref="net.sourceforge.ccxjc.it.ReferencedClass"/>
+    </jaxb:bindings>
+    <jaxb:bindings node=".//xs:complexType[@name='AdapterTestType']/xs:attribute[@name='standardMimeType']">
+      <jaxb:property>
+        <jaxb:baseType>
+          <jaxb:javaType name="jakarta.activation.MimeType"
+                         parseMethod="net.sourceforge.ccxjc.it.MimeTypeXmlAdapter.parseMimeType"
+                         printMethod="net.sourceforge.ccxjc.it.MimeTypeXmlAdapter.printMimeType"/>
+        </jaxb:baseType>
+      </jaxb:property>
+    </jaxb:bindings>
+    <jaxb:bindings node=".//xs:complexType[@name='AdapterTestType']/xs:attribute[@name='xjcMimeType']">
+      <jaxb:property>
+        <jaxb:baseType>
+          <xjc:javaType name="jakarta.activation.MimeType" adapter="net.sourceforge.ccxjc.it.MimeTypeXmlAdapter"/>
+        </jaxb:baseType>
+      </jaxb:property>
+    </jaxb:bindings>
+  </jaxb:bindings>
+</jaxb:bindings>

--- a/cc-xjc-it/src/main/jaxb/cc-xjc-it-indexed-no-value-class-package.xjb
+++ b/cc-xjc-it/src/main/jaxb/cc-xjc-it-indexed-no-value-class-package.xjb
@@ -29,9 +29,9 @@
 
 -->
 <jaxb:bindings xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-               xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               jaxb:version="2.0">
+               jaxb:version="3.0">
 
   <jaxb:bindings schemaLocation="../schemas/cc-xjc-it.xsd" node="/xs:schema">
     <jaxb:globalBindings generateValueClass="false" collectionType="indexed">

--- a/cc-xjc-it/src/main/jaxb/cc-xjc-it-indexed-no-value-class-private.xjb
+++ b/cc-xjc-it/src/main/jaxb/cc-xjc-it-indexed-no-value-class-private.xjb
@@ -29,9 +29,9 @@
 
 -->
 <jaxb:bindings xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-               xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               jaxb:version="2.0">
+               jaxb:version="3.0">
 
   <jaxb:bindings schemaLocation="../schemas/cc-xjc-it.xsd" node="/xs:schema">
     <jaxb:globalBindings generateValueClass="false" collectionType="indexed">

--- a/cc-xjc-it/src/main/jaxb/cc-xjc-it-indexed-no-value-class-protected.xjb
+++ b/cc-xjc-it/src/main/jaxb/cc-xjc-it-indexed-no-value-class-protected.xjb
@@ -29,9 +29,9 @@
 
 -->
 <jaxb:bindings xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-               xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               jaxb:version="2.0">
+               jaxb:version="3.0">
 
   <jaxb:bindings schemaLocation="../schemas/cc-xjc-it.xsd" node="/xs:schema">
     <jaxb:globalBindings generateValueClass="false" collectionType="indexed">

--- a/cc-xjc-it/src/main/jaxb/cc-xjc-it-indexed-no-value-class-public.xjb
+++ b/cc-xjc-it/src/main/jaxb/cc-xjc-it-indexed-no-value-class-public.xjb
@@ -29,9 +29,9 @@
 
 -->
 <jaxb:bindings xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-               xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               jaxb:version="2.0">
+               jaxb:version="3.0">
 
   <jaxb:bindings schemaLocation="../schemas/cc-xjc-it.xsd" node="/xs:schema">
     <jaxb:globalBindings generateValueClass="false" collectionType="indexed">

--- a/cc-xjc-it/src/main/jaxb/cc-xjc-it-indexed-package.xjb
+++ b/cc-xjc-it/src/main/jaxb/cc-xjc-it-indexed-package.xjb
@@ -29,9 +29,9 @@
 
 -->
 <jaxb:bindings xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-               xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               jaxb:version="2.0">
+               jaxb:version="3.0">
 
   <jaxb:bindings schemaLocation="../schemas/cc-xjc-it.xsd" node="/xs:schema">
     <jaxb:globalBindings collectionType="indexed">

--- a/cc-xjc-it/src/main/jaxb/cc-xjc-it-indexed-private.xjb
+++ b/cc-xjc-it/src/main/jaxb/cc-xjc-it-indexed-private.xjb
@@ -29,9 +29,9 @@
 
 -->
 <jaxb:bindings xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-               xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               jaxb:version="2.0">
+               jaxb:version="3.0">
 
   <jaxb:bindings schemaLocation="../schemas/cc-xjc-it.xsd" node="/xs:schema">
     <jaxb:globalBindings collectionType="indexed">

--- a/cc-xjc-it/src/main/jaxb/cc-xjc-it-indexed-protected.xjb
+++ b/cc-xjc-it/src/main/jaxb/cc-xjc-it-indexed-protected.xjb
@@ -29,9 +29,9 @@
 
 -->
 <jaxb:bindings xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-               xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               jaxb:version="2.0">
+               jaxb:version="3.0">
 
   <jaxb:bindings schemaLocation="../schemas/cc-xjc-it.xsd" node="/xs:schema">
     <jaxb:globalBindings collectionType="indexed">

--- a/cc-xjc-it/src/main/jaxb/cc-xjc-it-indexed-public.xjb
+++ b/cc-xjc-it/src/main/jaxb/cc-xjc-it-indexed-public.xjb
@@ -29,9 +29,9 @@
 
 -->
 <jaxb:bindings xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-               xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+               xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
                xmlns:xs="http://www.w3.org/2001/XMLSchema"
-               jaxb:version="2.0">
+               jaxb:version="3.0">
 
   <jaxb:bindings schemaLocation="../schemas/cc-xjc-it.xsd" node="/xs:schema">
     <jaxb:globalBindings collectionType="indexed">

--- a/cc-xjc-it/src/main/schemas/cc-xjc-it.xsd
+++ b/cc-xjc-it/src/main/schemas/cc-xjc-it.xsd
@@ -34,10 +34,10 @@
             targetNamespace="http://sourceforge.net/ccxjc/it"
             xmlns:ccxjcit="http://sourceforge.net/ccxjc/it"
             xmlns:xmime="http://www.w3.org/2005/05/xmlmime"
-            xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+            xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
             elementFormDefault="qualified"
             attributeFormDefault="unqualified"
-            jaxb:version="2.0">
+            jaxb:version="3.0">
   <xsd:annotation>
     <xsd:documentation xml:lang="en"><![CDATA[
 

--- a/cc-xjc-plugin/src/main/java/net/sourceforge/ccxjc/PluginImpl.java
+++ b/cc-xjc-plugin/src/main/java/net/sourceforge/ccxjc/PluginImpl.java
@@ -522,17 +522,17 @@ public final class PluginImpl extends Plugin
         {
             this.warnOnReferencedSupertypes( clazz );
 
-            if ( this.getStandardConstructor( clazz ) == null )
+            if ( this.getOrCreateStandardConstructor(clazz) == null )
             {
                 this.log( Level.WARNING, "couldNotAddStdCtor", clazz.implClass.binaryName() );
             }
 
-            if ( this.getCopyConstructor( clazz ) == null )
+            if ( this.getOrCreateCopyConstructor(clazz) == null )
             {
                 this.log( Level.WARNING, "couldNotAddCopyCtor", clazz.implClass.binaryName() );
             }
 
-            /*if ( this.getCloneMethod( clazz ) == null )
+            /*if ( this.getOrCreateCloneMethod(clazz) == null )
             {
                 this.log( Level.WARNING, "couldNotAddMethod", "clone", clazz.implClass.binaryName() );
             }*/
@@ -563,7 +563,7 @@ public final class PluginImpl extends Plugin
         return target <= this.targetJdk;
     }
 
-    private JMethod getStandardConstructor( final ClassOutline clazz )
+    private JMethod getOrCreateStandardConstructor(final ClassOutline clazz )
     {
         JMethod ctor = clazz.implClass.getConstructor( NO_ARGS );
         if ( ctor == null )
@@ -578,7 +578,7 @@ public final class PluginImpl extends Plugin
         return ctor;
     }
 
-    private JMethod getCopyConstructor( final ClassOutline clazz )
+    private JMethod getOrCreateCopyConstructor(final ClassOutline clazz )
     {
         JMethod ctor = clazz.implClass.getConstructor( new JType[]
             {
@@ -597,7 +597,7 @@ public final class PluginImpl extends Plugin
         return ctor;
     }
 
-    private JMethod getCloneMethod( final ClassOutline clazz )
+    private JMethod getOrCreateCloneMethod(final ClassOutline clazz )
     {
         JMethod clone = clazz.implClass.getMethod( "clone", NO_ARGS );
         if ( clone == null )

--- a/cc-xjc-plugin/src/main/java/net/sourceforge/ccxjc/PluginImpl.java
+++ b/cc-xjc-plugin/src/main/java/net/sourceforge/ccxjc/PluginImpl.java
@@ -151,6 +151,8 @@ public final class PluginImpl extends Plugin
 
     private static final String COPY_NULL_COLLECTION_ELEMENTS_OPTION_NAME = "-cc-null-collection-elements";
 
+    private static final String BASICS_COPYABLE_OPTION_NAME = "-Xcopyable";
+
     private static final String ELEMENT_SEPARATOR = ":";
 
     private static final List<String> DEFAULT_IMMUTABLE_TYPES = List.of(
@@ -281,6 +283,11 @@ public final class PluginImpl extends Plugin
     public int parseArgument( final Options opt, final String[] args, final int i )
         throws BadCommandLineException, IOException
     {
+        if ( args[i].equals( BASICS_COPYABLE_OPTION_NAME ) )
+        {
+            checkCloneableParameterCompatability(args, i);
+        }
+
         final StringBuilder supportedVisibilities = new StringBuilder( 1024 ).append( '[' );
         for ( Iterator<String> it = Arrays.asList( VISIBILITY_ARGUMENTS ).iterator(); it.hasNext(); )
         {
@@ -464,6 +471,22 @@ public final class PluginImpl extends Plugin
         return 0;
     }
 
+    private void checkCloneableParameterCompatability(String[] args, int i) throws BadCommandLineException {
+        final String option = "-" + OPTION_NAME;
+        final int indexOption = Arrays.asList(args).indexOf(option);
+        if ( indexOption >= 0 )
+        {
+            if ( i > indexOption )
+            {
+                throw new BadCommandLineException( getMessage( "cloneMethodArgumentOrder", BASICS_COPYABLE_OPTION_NAME, option ) );
+            }
+            else
+            {
+                this.log( Level.WARNING, "omitCloneMethodMessage", BASICS_COPYABLE_OPTION_NAME, option );
+            }
+        }
+    }
+
     private int parseTargetJdk(String targetArg ) {
         switch ( targetArg ) {
             case "1.5":
@@ -532,10 +555,10 @@ public final class PluginImpl extends Plugin
                 this.log( Level.WARNING, "couldNotAddCopyCtor", clazz.implClass.binaryName() );
             }
 
-            /*if ( this.getOrCreateCloneMethod(clazz) == null )
+            if ( this.getOrCreateCloneMethod(clazz) == null )
             {
                 this.log( Level.WARNING, "couldNotAddMethod", "clone", clazz.implClass.binaryName() );
-            }*/
+            }
         }
 
         this.log( Level.INFO, "report", this.methodCount, this.constructorCount, this.expressionCount );

--- a/cc-xjc-plugin/src/main/resources/net/sourceforge/ccxjc/PluginImpl.properties
+++ b/cc-xjc-plugin/src/main/resources/net/sourceforge/ccxjc/PluginImpl.properties
@@ -29,3 +29,5 @@ immutableTypesInfo=Immutable types: {0}
 stringTypesUsage=list of names of string based datatype classes separated by ''{0}''.
 stringTypesInfo=String types: {0}
 copyNullCollectionElementsUsage=copy ''null'' elements of collections in copy constructors. Default: disabled
+cloneMethodArgumentOrder=If "{0}" is used together with "{1}", you must specify "{0}" first to avoid duplicate clone-methods
+omitCloneMethodMessage=If "{0}" is used together with "{1}", cc-xjc will not write its own clone-method

--- a/cc-xjc-plugin/src/main/resources/net/sourceforge/ccxjc/PluginImpl_de.properties
+++ b/cc-xjc-plugin/src/main/resources/net/sourceforge/ccxjc/PluginImpl_de.properties
@@ -29,3 +29,5 @@ immutableTypesInfo=Unver\u00e4nderbare Typen: {0}
 stringTypesUsage=Liste von Namen zeichenkettenbasierter Datentyp-Klassen getrennt mit ''{0}''.
 stringTypesInfo=Zeichenkettenbasierte Datentypen: {0}
 copyNullCollectionElementsUsage=kopiert ''null''-Element von Collection im Kopier-Konstruktor. Standard: deaktiviert
+cloneMethodArgumentOrder=Wenn "{0}" zusammen mit "{1}" genutzt wird, muss "{0}" zuerst angegeben werden um doppelte clone-Methoden zu vermeiden
+omitCloneMethodMessage=Wenn "{0}" zusammen mit "{1}" genutzt wird, dann schreibt cc-xjc nicht seine eigene clone-Methode

--- a/cc-xjc-plugin/src/main/resources/net/sourceforge/ccxjc/PluginImpl_en.properties
+++ b/cc-xjc-plugin/src/main/resources/net/sourceforge/ccxjc/PluginImpl_en.properties
@@ -29,3 +29,5 @@ immutableTypesInfo=Immutable types: {0}
 stringTypesUsage=list of names of string based datatype classes separated by ''{0}''.
 stringTypesInfo=String types: {0}
 copyNullCollectionElementsUsage=copy ''null'' elements of collections in copy constructors. Default: disabled
+cloneMethodArgumentOrder=If "{0}" is used together with "{1}", you must specify "{0}" first to avoid duplicate clone-methods
+omitCloneMethodMessage=If "{0}" is used together with "{1}", cc-xjc will not write its own clone-method


### PR DESCRIPTION
This will fix missing clone method on when not using -Xcopyable

Additionally this will add checks on the order of -Xcopyable and
-copy-constructor to avoid confusion because of duplicated clone()
methods that are generated when using the wrong order. This is because
cc-xjc will respect existing clone()-methods but basics seems not to.

This bug was introduced in the jakarta migration.